### PR TITLE
Feat/#14 social login kakao

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // feignClient
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/with/picme/PicmeApplication.java
+++ b/src/main/java/com/with/picme/PicmeApplication.java
@@ -2,7 +2,9 @@ package com.with.picme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class PicmeApplication {
 

--- a/src/main/java/com/with/picme/common/SocialType.java
+++ b/src/main/java/com/with/picme/common/SocialType.java
@@ -1,0 +1,5 @@
+package com.with.picme.common;
+
+public enum SocialType {
+    kakao
+}

--- a/src/main/java/com/with/picme/common/message/ErrorMessage.java
+++ b/src/main/java/com/with/picme/common/message/ErrorMessage.java
@@ -23,7 +23,7 @@ public enum ErrorMessage {
     EMPTY_TOKEN("빈 토큰입니다."),
     INVALID_PASSWORD("잘못된 비밀번호입니다."),
     INVALID_EMAIL("잘못된 이메일입니다."),
-  
+
     /**
     * exception
     **/
@@ -38,7 +38,14 @@ public enum ErrorMessage {
     /**
      * user
      */
-    CANT_GET_USERINFO("유저 아이디를 갖고올 수 없습니다.");
+    CANT_GET_USERINFO("유저 아이디를 갖고올 수 없습니다."),
+
+
+    /*
+    * social
+     */
+    NO_SOCIAL_TYPE("제공하는 소셜 서비스가 다릅니다."),
+    NO_SOCIAL_USER("소셜 서비스에 가입하지 않은 유저입니다");
 
     private final String message;
 }

--- a/src/main/java/com/with/picme/common/message/ErrorMessage.java
+++ b/src/main/java/com/with/picme/common/message/ErrorMessage.java
@@ -45,7 +45,8 @@ public enum ErrorMessage {
     * social
      */
     NO_SOCIAL_TYPE("제공하는 소셜 서비스가 다릅니다."),
-    NO_SOCIAL_USER("소셜 서비스에 가입하지 않은 유저입니다");
+    NO_SOCIAL_USER("소셜 서비스에 가입하지 않은 유저입니다"),
+    NOT_FOUND_SOCIAL_TOKEN("소셜로그인 토큰이 유효하지 않습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/with/picme/common/message/ResponseMessage.java
+++ b/src/main/java/com/with/picme/common/message/ResponseMessage.java
@@ -21,8 +21,12 @@ public enum ResponseMessage {
     /*
     user
      */
-    GET_USER_INFO("유저 정보 갖고오기 성공");
+    GET_USER_INFO("유저 정보 갖고오기 성공"),
 
+    /*
+    social
+     */
+    CHECK_KAKAO_USER_SUCCESS("카카오 계정 확인 성공");
 
     private final String message;
     }

--- a/src/main/java/com/with/picme/config/KakaoAuth.java
+++ b/src/main/java/com/with/picme/config/KakaoAuth.java
@@ -1,0 +1,14 @@
+package com.with.picme.config;
+
+
+import com.with.picme.dto.auth.kakao.KakaoUserResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoAuth", url = "https://kapi.kakao.com")
+public interface KakaoAuth {
+
+    @GetMapping("/v2 /user/me")
+    KakaoUserResponseDto getProfileInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/com/with/picme/config/kakao/KakaoAuth.java
+++ b/src/main/java/com/with/picme/config/kakao/KakaoAuth.java
@@ -1,4 +1,4 @@
-package com.with.picme.config;
+package com.with.picme.config.kakao;
 
 
 import com.with.picme.dto.auth.kakao.KakaoUserResponseDto;
@@ -9,6 +9,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @FeignClient(name = "kakaoAuth", url = "https://kapi.kakao.com")
 public interface KakaoAuth {
 
-    @GetMapping("/v2 /user/me")
+    @GetMapping("/v2/user/me")
     KakaoUserResponseDto getProfileInfo(@RequestHeader("Authorization") String accessToken);
 }

--- a/src/main/java/com/with/picme/config/kakao/KakaoAuthImpl.java
+++ b/src/main/java/com/with/picme/config/kakao/KakaoAuthImpl.java
@@ -1,0 +1,49 @@
+package com.with.picme.config.kakao;
+
+import com.with.picme.common.message.ErrorMessage;
+import com.with.picme.dto.auth.kakao.KakaoUser;
+import com.with.picme.dto.auth.kakao.KakaoUserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityNotFoundException;
+
+import static com.with.picme.common.message.ErrorMessage.*;
+
+@RequiredArgsConstructor
+@Component
+public class KakaoAuthImpl implements KakaoAuth {
+    private final KakaoAuth kakaoAuth;
+
+    @Override
+    public KakaoUserResponseDto getProfileInfo(String accessToken) {
+        try {
+            KakaoUserResponseDto kakaoProfile = kakaoAuth.getProfileInfo(accessToken);
+            return kakaoProfile;
+        } catch (Exception e) {
+            throw new EntityNotFoundException(ErrorMessage.NOT_FOUND_SOCIAL_TOKEN.getMessage());
+        }
+    }
+
+    public KakaoUser getKakaoUser(String accessToken){
+        KakaoUserResponseDto user = this.getProfileInfo(accessToken);
+        checkSocialUser(user);
+        KakaoUser kakaoUser = checkSocialUserHaveEmail(user);
+        return kakaoUser;
+    }
+
+    private boolean checkSocialUser(KakaoUserResponseDto kakaoUser){
+        if (kakaoUser.id() == null){
+            throw new IllegalArgumentException(NO_SOCIAL_USER.getMessage());
+        }
+        return true;
+    }
+
+    private KakaoUser checkSocialUserHaveEmail(KakaoUserResponseDto kakaoUserResponseDto){
+        String email = "";
+        if (kakaoUserResponseDto.kakao_account().email() != null) {
+            email = kakaoUserResponseDto.kakao_account().email();
+        }
+        return KakaoUser.of(kakaoUserResponseDto.id(), email);
+    }
+}

--- a/src/main/java/com/with/picme/config/kakao/KakaoAuthImpl.java
+++ b/src/main/java/com/with/picme/config/kakao/KakaoAuthImpl.java
@@ -27,14 +27,16 @@ public class KakaoAuthImpl implements KakaoAuth {
 
     public KakaoUser getKakaoUser(String accessToken){
         KakaoUserResponseDto user = this.getProfileInfo(accessToken);
-        checkSocialUser(user);
+        if(!checkSocialUser(user)){
+            throw new IllegalArgumentException(NO_SOCIAL_USER.getMessage());
+        };
         KakaoUser kakaoUser = checkSocialUserHaveEmail(user);
         return kakaoUser;
     }
 
     private boolean checkSocialUser(KakaoUserResponseDto kakaoUser){
         if (kakaoUser.id() == null){
-            throw new IllegalArgumentException(NO_SOCIAL_USER.getMessage());
+            return false;
         }
         return true;
     }

--- a/src/main/java/com/with/picme/controller/AuthController.java
+++ b/src/main/java/com/with/picme/controller/AuthController.java
@@ -1,10 +1,8 @@
 package com.with.picme.controller;
 
 import com.with.picme.common.ApiResponse;
-import com.with.picme.dto.auth.AuthSignInRequestDto;
-import com.with.picme.dto.auth.AuthSignInResponseDto;
-import com.with.picme.dto.auth.AuthSignUpRequestDto;
-import com.with.picme.dto.auth.AuthSignUpResponseDto;
+import com.with.picme.dto.auth.*;
+import com.with.picme.dto.auth.kakao.KakaoUser;
 import com.with.picme.service.AuthServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,5 +30,11 @@ public class AuthController {
     public ResponseEntity<ApiResponse> signInUser(@RequestBody AuthSignInRequestDto request) {
         AuthSignInResponseDto response = authService.signInUser(request);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_SIGN_IN.getMessage(), response));
+    }
+
+    @PostMapping("/kakao/check")
+    public ResponseEntity<ApiResponse> findSocialUser(@RequestBody @Valid  AuthSocialCheckRequestDto request) {
+        KakaoUser user = authService.getUser(request);
+        return null;
     }
 }

--- a/src/main/java/com/with/picme/controller/AuthController.java
+++ b/src/main/java/com/with/picme/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.with.picme.controller;
 import com.with.picme.common.ApiResponse;
 import com.with.picme.dto.auth.*;
 import com.with.picme.dto.auth.kakao.KakaoUser;
+import com.with.picme.entity.User;
+import com.with.picme.repository.AuthenticationProviderRepository;
 import com.with.picme.service.AuthServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,14 +13,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
-import static com.with.picme.common.message.ResponseMessage.SUCCESS_SIGN_IN;
-import static com.with.picme.common.message.ResponseMessage.SUCCESS_SIGN_UP;
+
+
+import static com.with.picme.common.message.ResponseMessage.*;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthServiceImpl authService;
+    private final AuthenticationProviderRepository authenticationProviderRepository;
 
     @PostMapping("")
     public ResponseEntity<ApiResponse> createUser(@RequestBody @Valid AuthSignUpRequestDto request) {
@@ -33,8 +37,15 @@ public class AuthController {
     }
 
     @PostMapping("/kakao/check")
-    public ResponseEntity<ApiResponse> findSocialUser(@RequestBody @Valid  AuthSocialCheckRequestDto request) {
-        KakaoUser user = authService.getUser(request);
-        return null;
+    public ResponseEntity<ApiResponse> findSocialUser(@RequestBody AuthSocialCheckRequestDto request) {
+        KakaoUser user  = authService.getUser(request);
+        User existUser = authService.findByKey(user);
+        AuthSocialCheckResponseDto response ;
+        if (existUser==null)
+            response = AuthSocialCheckResponseDto.of(user.userId(),user.email(),false);
+        else{
+            response = AuthSocialCheckResponseDto.of(user.userId(),user.email(),true);
+        }
+        return ResponseEntity.ok(ApiResponse.success(CHECK_KAKAO_USER_SUCCESS.getMessage(),response));
     }
 }

--- a/src/main/java/com/with/picme/controller/AuthController.java
+++ b/src/main/java/com/with/picme/controller/AuthController.java
@@ -38,14 +38,7 @@ public class AuthController {
 
     @PostMapping("/kakao/check")
     public ResponseEntity<ApiResponse> findSocialUser(@RequestBody AuthSocialCheckRequestDto request) {
-        KakaoUser user  = authService.getUser(request);
-        User existUser = authService.findByKey(user);
-        AuthSocialCheckResponseDto response ;
-        if (existUser==null)
-            response = AuthSocialCheckResponseDto.of(user.userId(),user.email(),false);
-        else{
-            response = AuthSocialCheckResponseDto.of(user.userId(),user.email(),true);
-        }
+        AuthSocialCheckResponseDto response = authService.findSocialUser(request);
         return ResponseEntity.ok(ApiResponse.success(CHECK_KAKAO_USER_SUCCESS.getMessage(),response));
     }
 }

--- a/src/main/java/com/with/picme/dto/auth/AuthSocialCheckRequestDto.java
+++ b/src/main/java/com/with/picme/dto/auth/AuthSocialCheckRequestDto.java
@@ -1,0 +1,14 @@
+package com.with.picme.dto.auth;
+
+
+import javax.validation.constraints.NotBlank;
+
+
+public record AuthSocialCheckRequestDto(
+        @NotBlank(message="필요한 값이 없습니다")
+        String socialType,
+
+        @NotBlank(message = "필요한 값이 없습니다.")
+        String token
+) {
+}

--- a/src/main/java/com/with/picme/dto/auth/AuthSocialCheckResponseDto.java
+++ b/src/main/java/com/with/picme/dto/auth/AuthSocialCheckResponseDto.java
@@ -1,0 +1,20 @@
+package com.with.picme.dto.auth;
+
+import lombok.Builder;
+
+@Builder
+public record AuthSocialCheckResponseDto (
+        Long uid,
+        String email,
+        boolean isUser
+){
+    public static AuthSocialCheckResponseDto of(Long uid, String email, boolean isUser){
+        return AuthSocialCheckResponseDto
+                .builder()
+                .uid(uid)
+                .email(email)
+                .isUser(isUser)
+                .build();
+
+    }
+}

--- a/src/main/java/com/with/picme/dto/auth/kakao/KakaoAccount.java
+++ b/src/main/java/com/with/picme/dto/auth/kakao/KakaoAccount.java
@@ -1,0 +1,16 @@
+package com.with.picme.dto.auth.kakao;
+
+import com.with.picme.config.KakaoAuth;
+import lombok.Builder;
+
+@Builder
+public record KakaoAccount(
+        String email
+) {
+    public static KakaoAccount of(String email){
+        return KakaoAccount
+                .builder()
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/with/picme/dto/auth/kakao/KakaoAccount.java
+++ b/src/main/java/com/with/picme/dto/auth/kakao/KakaoAccount.java
@@ -1,6 +1,5 @@
 package com.with.picme.dto.auth.kakao;
 
-import com.with.picme.config.KakaoAuth;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/with/picme/dto/auth/kakao/KakaoUser.java
+++ b/src/main/java/com/with/picme/dto/auth/kakao/KakaoUser.java
@@ -1,20 +1,21 @@
 package com.with.picme.dto.auth.kakao;
 
-import com.with.picme.config.KakaoAuth;
+
+import com.with.picme.entity.ProviderType;
 import lombok.Builder;
 
 @Builder
 public record KakaoUser(
         Long userId,
         String email,
-        String providerType
+        ProviderType providerType
 ) {
     public static KakaoUser of(Long userId, String email){
         return KakaoUser
                 .builder()
                 .userId(userId)
                 .email(email)
-                .providerType("kakao")
+                .providerType(ProviderType.kakao)
                 .build();
     }
 }

--- a/src/main/java/com/with/picme/dto/auth/kakao/KakaoUser.java
+++ b/src/main/java/com/with/picme/dto/auth/kakao/KakaoUser.java
@@ -1,0 +1,20 @@
+package com.with.picme.dto.auth.kakao;
+
+import com.with.picme.config.KakaoAuth;
+import lombok.Builder;
+
+@Builder
+public record KakaoUser(
+        Long userId,
+        String email,
+        String providerType
+) {
+    public static KakaoUser of(Long userId, String email){
+        return KakaoUser
+                .builder()
+                .userId(userId)
+                .email(email)
+                .providerType("kakao")
+                .build();
+    }
+}

--- a/src/main/java/com/with/picme/dto/auth/kakao/KakaoUserResponseDto.java
+++ b/src/main/java/com/with/picme/dto/auth/kakao/KakaoUserResponseDto.java
@@ -1,0 +1,18 @@
+package com.with.picme.dto.auth.kakao;
+
+
+import lombok.Builder;
+
+@Builder
+public record KakaoUserResponseDto(
+        Long id,
+        KakaoAccount kakao_account
+) {
+    public static KakaoUserResponseDto of(Long id, KakaoAccount kakaoAccount) {
+        return KakaoUserResponseDto
+                .builder()
+                .id(id)
+                .kakao_account(kakaoAccount)
+                .build();
+    }
+}

--- a/src/main/java/com/with/picme/entity/AuthenticationProvider.java
+++ b/src/main/java/com/with/picme/entity/AuthenticationProvider.java
@@ -13,6 +13,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @Setter
 @Entity
 @NoArgsConstructor
+@Table(name = "\"AuthenticationProvider\"")
 public class AuthenticationProvider {
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -20,6 +21,7 @@ public class AuthenticationProvider {
     private Long id;
 
     @Column(name="provider_type")
+    @Enumerated(EnumType.STRING)
     private ProviderType provider;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/with/picme/entity/ProviderType.java
+++ b/src/main/java/com/with/picme/entity/ProviderType.java
@@ -1,5 +1,9 @@
 package com.with.picme.entity;
 
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
 public enum ProviderType {
+    @Enumerated(EnumType.STRING)
     kakao, naver, google
 }

--- a/src/main/java/com/with/picme/repository/AuthenticationProviderRepository.java
+++ b/src/main/java/com/with/picme/repository/AuthenticationProviderRepository.java
@@ -10,8 +10,5 @@ import java.util.Optional;
 
 public interface AuthenticationProviderRepository extends JpaRepository<AuthenticationProvider, Long> {
     @EntityGraph(attributePaths = "user")
-    Optional<AuthenticationProvider> findById(Long id);
-
-    @EntityGraph(attributePaths = "user")
     Optional<AuthenticationProvider> findByIdAndProvider(Long id, ProviderType providerType);
 }

--- a/src/main/java/com/with/picme/repository/AuthenticationProviderRepository.java
+++ b/src/main/java/com/with/picme/repository/AuthenticationProviderRepository.java
@@ -1,0 +1,17 @@
+package com.with.picme.repository;
+
+import com.with.picme.entity.AuthenticationProvider;
+import com.with.picme.entity.ProviderType;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+import java.util.Optional;
+
+public interface AuthenticationProviderRepository extends JpaRepository<AuthenticationProvider, Long> {
+    @EntityGraph(attributePaths = "user")
+    Optional<AuthenticationProvider> findById(Long id);
+
+    @EntityGraph(attributePaths = "user")
+    Optional<AuthenticationProvider> findByIdAndProvider(Long id, ProviderType providerType);
+}

--- a/src/main/java/com/with/picme/service/AuthService.java
+++ b/src/main/java/com/with/picme/service/AuthService.java
@@ -11,7 +11,5 @@ public interface AuthService {
 
     AuthSignUpResponseDto createUser(AuthSignUpRequestDto request);
     AuthSignInResponseDto signInUser(AuthSignInRequestDto request);
-    KakaoUser getUser(AuthSocialCheckRequestDto request);
-
-    User findByKey(KakaoUser of);
+    AuthSocialCheckResponseDto findSocialUser(AuthSocialCheckRequestDto request);
 }

--- a/src/main/java/com/with/picme/service/AuthService.java
+++ b/src/main/java/com/with/picme/service/AuthService.java
@@ -2,10 +2,16 @@ package com.with.picme.service;
 
 import com.with.picme.dto.auth.*;
 import com.with.picme.dto.auth.kakao.KakaoUser;
+import com.with.picme.entity.AuthenticationProvider;
+import com.with.picme.entity.User;
+
+import java.util.Optional;
 
 public interface AuthService {
 
     AuthSignUpResponseDto createUser(AuthSignUpRequestDto request);
     AuthSignInResponseDto signInUser(AuthSignInRequestDto request);
     KakaoUser getUser(AuthSocialCheckRequestDto request);
+
+    User findByKey(KakaoUser of);
 }

--- a/src/main/java/com/with/picme/service/AuthService.java
+++ b/src/main/java/com/with/picme/service/AuthService.java
@@ -1,12 +1,11 @@
 package com.with.picme.service;
 
-import com.with.picme.dto.auth.AuthSignInRequestDto;
-import com.with.picme.dto.auth.AuthSignInResponseDto;
-import com.with.picme.dto.auth.AuthSignUpRequestDto;
-import com.with.picme.dto.auth.AuthSignUpResponseDto;
+import com.with.picme.dto.auth.*;
+import com.with.picme.dto.auth.kakao.KakaoUser;
 
 public interface AuthService {
 
     AuthSignUpResponseDto createUser(AuthSignUpRequestDto request);
     AuthSignInResponseDto signInUser(AuthSignInRequestDto request);
+    KakaoUser getUser(AuthSocialCheckRequestDto request);
 }


### PR DESCRIPTION
<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->

## 🖼️ 작업한 내용
- 카카오 유저 체크 & 이미 회원가입한 사용자인지 체크하는 
  [카카오 중복 체크]를 구현했습니다.


## 📸 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 로직 flow를 노드랑 똑같이 해봤습니다. 그러다보니 컨트롤러에서 data를 리턴하는부분이, if-else로직이 들어가서 좀 지저분 해지는 것 같습니다.
 -> 이 부분을 서비스 로직으로 옮기는 것은 어떠실련지요 ?
- @FeignClient 를 사용하여 kakaoApi 서버와 통신해봤습니다.
- kakaoAuth관련한 로직을 AuthService에 넣으면 코드가 지저분해져서, kakaoAuth를 implementation한 KakaoAuthImpl클래스를 구현하여 kakaoAuth에 필요한 메서드를 묶어놨습니다.

- 또한 이슈가 있었는데, Authentication에서 ProviderType이 spring의 enum타입으로 되어, DB 숫자로 인식됐기 때문에, String으로 변환해주는 어노테이션을 AuthenticationProvider, ProviderType에 추가하여 이슈를 해결했습니다.
- 또한 AuthenticationProvider를 Spring jpa 메소드를 통해 가져올 때 user프로퍼티의 지연로딩으로 인해, 프록시 객체가 가져와져, AuthenticationProviderRepository에서 fetchjoin을 통해 갖고올 수 있게 구현했습니다. 


## ✍️ 관련 이슈
- Resolved: #14 
